### PR TITLE
fix: list index out of range error when parsing ifeq that has an empty first argument

### DIFF
--- a/pymake/parsermk.py
+++ b/pymake/parsermk.py
@@ -74,7 +74,7 @@ def parse_ifeq_conditionals(ifeq_expr, directive_vstr):
     def kill_trailing_ws(token_list):
         if _my_debug:
             print("kill trailing whitespace")
-        if token_list[-1].is_whitespace():
+        if token_list and token_list[-1].is_whitespace():
             token_list.pop()
 
 #    def kill_leading_ws(token):

--- a/tests/test_ifeq_parse.py
+++ b/tests/test_ifeq_parse.py
@@ -165,3 +165,6 @@ def test_too_many_expressions():
     s = "ifeq (1,1,1)"
     _should_succeed(s,("1", "1,1"))
 
+def test_empty_first_arg():
+    s = "ifeq (,1)"
+    _should_succeed(s, ("", "1"))


### PR DESCRIPTION
Example:

```makefile
download:
ifeq (,$(wildcard ./glob.c))
    curl … -o glob.c
endif
```
