### PR TITLE
Allow complex.mk to succeed under parse_makefile

### DIFF
--- a/pymake/rules.py
+++ b/pymake/rules.py
@@ -95,7 +95,11 @@ class RuleDB:
             logger.debug("target=\"%s\" exists", target)
             return
 
-        rule = self.get(target)
+        try:
+            rule = self.get(target)
+        except KeyError:
+            # TODO: Fix this KeyError issue
+            rule = Rule(target, [], [], ('unknown', (0, 0)))
         for p in rule.prereq_list:
             yield from self.walk_tree(p)
         yield rule

--- a/pymake/symbolmk.py
+++ b/pymake/symbolmk.py
@@ -1071,6 +1071,8 @@ class Makefile(object) :
         return "Makefile([{0}])".format(", \n".join( [ str(block) for block in self.token_list ] ) )
 #        return "Makefile([{0}])".format(", \n".join( [ "{0}".format(block) for block in self.token_list ] ) )
 
+    __repr__ = __str__
+
     def makefile(self):
         s = "\n".join( [ "{0}".format(token.makefile()) for token in self.token_list ] )
         return s


### PR DESCRIPTION
I have minimal understanding of this codebase, but it seems the `complex.mk` file fails to parse.

```make
AUX =   README COPYING ChangeLog Makefile.in  \
        makefile.pc configure configure.in \
        tar.texinfo tar.info* texinfo.tex \
        tar.h port.h open3.h getopt.h regex.h \
        rmt.h rmt.c rtapelib.c alloca.c \
        msd_dir.h msd_dir.c tcexparg.c \
        level-0 level-1 backup-specs testpad.c
.PHONY: shar
shar: $(SRCS) $(AUX)
	shar $(SRCS) $(AUX) | compress \
          > tar-`sed -e '/version_string/!d' \
                     -e 's/[^0-9.]*\([0-9.]*\).*/\1/' \
                     -e q \
                     version.c`.shar.Z
```