### PR TITLE
re-enable include statements

### DIFF
--- a/pymake/parsermk.py
+++ b/pymake/parsermk.py
@@ -484,17 +484,25 @@ def parse_define_block(expr, virt_line, vline_iter ):
 #    # TODO any validity checks I need to do here? (Probably)
 #    raise NotImplementedError(directive_vstr)
 
-def parse_include_directive(expr, directive_vstr, *ignore):
+def parse_include_directive(directive_vstr, virt_line, _):
     # ha ha type checking
-    _ = expr.token_list
+    _ = directive_vstr.vchars
+    _ = virt_line.remain
 
-    # TODO any validity checks I need to do here? (Probably)
+    starting_pos = directive_vstr.get_pos()
+
     dir_str = str(directive_vstr)
     
     klass = include_directive_lut[dir_str]
 
+    vchar_scanner = ScannerIterator(virt_line.remain(), starting_pos[0])
+    token_list = tokenizer.tokenize_line(vchar_scanner)
+    if not token_list:
+        # bare include is not an error (seems to be ignored)
+        return klass(directive_vstr)
+
     # note we're passing in the parse function
-    return klass(directive_vstr, expr)
+    return klass(directive_vstr, Expression(token_list))
 
 def handle_conditional_directive(directive_inst, vline_iter):
     # GNU make doesn't parse the stuff inside the conditional unless the

--- a/pymake/pymake.py
+++ b/pymake/pymake.py
@@ -94,7 +94,6 @@ def parse_vline(virt_line, vline_iter):
     # seek export | unexport
     vstr = tokenizer.seek_directive(vchar_scanner, set(("export","unexport")))
     if vstr:
-        # TODO
         e = parsermk.parse_directive(vstr, vchar_scanner, vline_iter)
         assert e
         return e
@@ -111,8 +110,10 @@ def parse_vline(virt_line, vline_iter):
     # seek include
     vstr = tokenizer.seek_directive(vchar_scanner, include_directive)
     if vstr:
-        # TODO
-        raise NotImplementedError(str(vstr))
+        d = parsermk.parse_directive( vstr, vchar_scanner, vline_iter)
+        assert d
+        return d
+
     assert vchar_scanner.is_starting(), vchar_scanner.get_pos()
 
     # How does GNU Make decide something is a rule?

--- a/pymake/symbolmk.py
+++ b/pymake/symbolmk.py
@@ -732,8 +732,13 @@ class UnExportDirective(ExportDirective):
 class IncludeDirective(Directive):
     name = "include"
 
-    def __init__(self, keyword, expression):
+    def __init__(self, keyword, expression=None):
         self.source = None
+
+        # if expression is None then we found a bar 'include' in the source.
+        # GNU Make ignores it but let's throw a warning.
+        if expression is None:
+            warning_message(keyword.get_pos(), "ignore include with no target")
 
         super().__init__(keyword, expression)
 
@@ -749,6 +754,11 @@ class IncludeDirective(Directive):
     # TODO So I'll need a way of caching the file include failures. Will need
     # to retry between execute() and running the Rules.
     def eval(self, symbol_table):
+        if self.expression is None:
+            # GNU Make strangely allows a bare 'include' which is summarily
+            # ignored.
+            return ""
+
         s = self.expression.eval(symbol_table)
 
         # GNU Make ignores an empty include

--- a/pymake/symtablemk.py
+++ b/pymake/symtablemk.py
@@ -97,8 +97,6 @@ class Entry:
         # vs   a:=10  (evaluated immediately and "10" stored in symtable)
         #
         if isinstance(self._value, Symbol):
-            if self.name=='include':
-                breakpoint()
             logger.debug("recursive eval %r name=%s at pos=%r", self, self.name, self.get_pos())
             if self.loop > 0:
                 msg = "Recursive variable %r references itself (eventually)" % self.name

--- a/tests/include.mk
+++ b/tests/include.mk
@@ -1,26 +1,40 @@
-include smallest.mk
+rulefile:=$(wildcard smallest.mk)
+ifeq (${rulefile},)
+    # didn't find in the current directory; let's try under our tests
+    rulefile:=$(wildcard tests/smallest.mk)
+    ifeq (${rulefile},)
+        $(error unable to find smallest.mk)
+    endif
+endif
+$(info will include $(rulefile) for rules)
+
+include $(rulefile)
 -include noname.mk
 sinclude noname.mk
 
-# this tries to include four files: =,foo,bar,baz
+# this creates a variable named 'include'
+# (doesn't include a file named '=')
 include = foo bar baz
+ifndef include
+$(error should have been a variable)
+endif
 $(info include=$(include))
 
 # an assignment expression
 include=foo bar baz
-#ifndef include
-#$(error include required)
-#endif
+ifndef include
+$(error include required)
+endif
 $(info include=$(include))
-#ifneq ($(include),foo bar baz)
-#$(error include should have been foo bar baz)
-#endif
+ifneq ($(include),foo bar baz)
+$(error include should have been foo bar baz)
+endif
 
 # bare include is not an error; seems to be ignored
 include
 
 filename=noname.mk
-include $(filename)
+-include $(filename)
 
 # parses to a rule "include a" with target =b ???
 #include a+=b
@@ -28,6 +42,7 @@ include $(filename)
 # What in the holy hell. Make hitting implicit catch-all for missing include
 # names? WTF?
 # 
+# TODO
 # "Once it has finished reading makefiles, make will try to remake any that are
 # out of date or don’t exist. See Section 3.5 [How Makefiles Are Remade], page
 # 14.  Only after it has tried to find a way to remake a makefile and failed,
@@ -48,5 +63,5 @@ include $(filename)
 # 4.0
 # {implicit} noname.mk
 
-% : ; @echo {implicit} $@
+#% : ; @echo {implicit} $@
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0
+
 import os
 import sys
 import tempfile
@@ -134,3 +136,10 @@ def pymake_should_fail(makefile, extra_args=None, extra_env=None):
 
 def gnumake_should_fail(makefile, extra_args=None, extra_env=None):
     return _should_fail(gnumake_string, makefile, extra_args, extra_env)
+
+# run both make and pymake
+# for a test simple enough for a pass/fail
+def simple_test(makefile):
+    output = gnumake_string(makefile)
+    output = pymake_string(makefile)
+

--- a/tests/test_ifdef.py
+++ b/tests/test_ifdef.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0
+
 import pytest
 
 import run
@@ -5,8 +7,7 @@ import run
 # run both make and pymake
 # these ifdef tests are simple enough for a pass/fail
 def run_test(makefile):
-    output = run.gnumake_string(makefile)
-    output = run.pymake_string(makefile)
+    run.simple_test(makefile)
 
 def test_ifdef_mixed_build():
     # If the value of that variable has a non-empty value, the text-if-true

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import tempfile
+
+import pytest
+
+import run
+
+# Jump through some strange hoops to write two temporary files.
+# GNU make allows multiple arguments to the include directive.
+def run_two_files(s):
+    with tempfile.NamedTemporaryFile(buffering=0, delete=os.name != 'nt') as outfile1:
+        with tempfile.NamedTemporaryFile(buffering=0, delete=os.name != 'nt') as outfile2:
+            outfile1.write(b"$(info hello from outfile1)\n")
+            outfile2.write(b"$(info hello from outfile2)\n")
+            makefile_s = s % (outfile1.name, outfile2.name)
+
+            try:
+                gnumake_stdout = run.gnumake_string(makefile_s)
+                print("gnu make stdout=\"%s\"" % gnumake_stdout)
+                pymake_stdout = run.pymake_string(makefile_s)
+                print("pymake stdout=\"%s\"" % pymake_stdout)
+
+                assert gnumake_stdout==pymake_stdout, (gnumake_stdout, pymake_stdout)
+            finally:
+                if os.name == 'nt':
+                    outfile1.close()
+                    outfile2.close()
+                    os.remove(outfile1.name)
+                    os.remove(outfile2.name)
+    
+
+def test1():
+    s = """
+include /dev/null
+@:;@:
+"""
+    run.simple_test(s)    
+
+def test_leading_tab():
+    # GNU make will allow a <tab> leading an include statement
+    s = """
+	include /dev/null
+@:;@:
+"""
+    run.simple_test(s)    
+
+def test_sinclude():
+    s = """
+sinclude /path/does/not/exist
+@:;@:
+"""
+    run.simple_test(s)    
+
+def test_dash_include():
+    s = """
+-include /path/does/not/exist
+@:;@:
+"""
+    run.simple_test(s)    
+
+def test_include_assignment():
+    s = """
+include:=/path/does/not/exist
+ifneq ($(include),/path/does/not/exist)
+$(error fail)
+endif
+@:;@:
+"""
+    run.simple_test(s)    
+
+def test_whitespace():
+    s = """
+		include /dev/null
+@:;@:
+"""
+    run.simple_test(s)
+
+def test_include_fail():
+    s = """
+include /path/does/not/exist
+@:;@:
+"""
+    run.gnumake_should_fail(s)
+    run.pymake_should_fail(s)
+
+def test_include_two_files():
+    s = """
+include %s %s
+@:;@:
+"""
+    run_two_files(s)
+
+def test_include_two_files_tab():
+    # separate filenames by tab(s)
+    s = """
+include 	%s		%s
+@:;@:
+"""
+    run_two_files(s)
+
+def test_include_varref():
+    s = """
+FILENAME:=/dev/null
+include ${FILENAME}
+@:;@:
+"""
+    run.simple_test(s)
+
+def test_include_varref():
+    s = """
+FILENAME:=/dev/null
+include ${FILENAME}
+@:;@:
+"""
+    run.simple_test(s)
+
+def test_wildcard():
+    s = """
+include $(wildcard /dev/null)
+@:;@:
+"""
+    run.simple_test(s)
+
+@pytest.mark.skip(reason="FIXME broken in pymake")
+def test_generated_makefile():
+    # "Once it has finished reading makefiles, make will try to remake any that are
+    # out of date or don’t exist. See Section 3.5 [How Makefiles Are Remade], page
+    # 14.  Only after it has tried to find a way to remake a makefile and failed,
+    # will make diagnose the missing makefile as a fatal error."  
+    s = """
+include {0}
+
+{0}:
+	touch {0}
+
+@:;@:
+"""
+    include_name = "tst.mk"
+    makefile_s = s.format(include_name)
+
+    with tempfile.TemporaryDirectory() as outdirname:
+        filename = os.path.join(outdirname, include_name)
+        with open(filename,"wb", buffering=0) as outfile:
+            outfile.write("$(info hello from {})".format(include_name).encode("utf8"))
+
+            gnumake_stdout = run.gnumake_string(makefile_s)
+            print("gnu make stdout=\"%s\"" % gnumake_stdout)
+
+            pymake_stdout = run.pymake_string(makefile_s)
+            print("pymake stdout=\"%s\"" % gnumake_stdout)
+

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -111,6 +111,8 @@ infilename_list = (
     "assign.mk",
     "multiline.mk",
     "ignoreandsilent.mk",
+    
+    "include.mk"
     # "automatic.mk",
 )
 


### PR DESCRIPTION
Note implemented yet: the GNU make feature that looks for rules to generate a missing include target

- add include test code
- move some convenience test code into main test runner