### PR TITLE
dpoole/shell recursive vars

### DIFF
--- a/pymake/error.py
+++ b/pymake/error.py
@@ -103,7 +103,7 @@ class MissingEndef(ParseError):
     default_msg = "missing 'endef', unterminated 'define'"
 
 class RecursiveVariableError(MakeError):
-    default_msg = "Recursive variable <name> references itself eventually"
+    default_msg = "Recursive variable <name> references itself eventually."
 
 #class VersionError(MakeError):
 #    """Feature not in this version"""

--- a/pymake/error.py
+++ b/pymake/error.py
@@ -13,6 +13,7 @@ __all__ = [ "ParseError",
             "NoMakefileFound",
             "InternalError",
             "MissingEndef",
+            "RecursiveVariableError",
 
             "warning_message",
             "error_message",
@@ -100,6 +101,9 @@ class InternalError(MakeError):
 
 class MissingEndef(ParseError):
     default_msg = "missing 'endef', unterminated 'define'"
+
+class RecursiveVariableError(MakeError):
+    default_msg = "Recursive variable <name> references itself eventually"
 
 #class VersionError(MakeError):
 #    """Feature not in this version"""

--- a/pymake/error.py
+++ b/pymake/error.py
@@ -106,12 +106,18 @@ class MissingEndef(ParseError):
 #    pass
 
 def warning_message(pos, msg):
+    # don't allow an empty message because it's super confusing
+    assert msg
+
     if pos:
         print("%s %r warning: %s" % (pos[0], pos[1], msg), file=sys.stderr)
     else:
         print("(pos unknown): %s" % (msg,), file=sys.stderr)
 
 def error_message(pos, msg):
+    # don't allow an empty message because it's super confusing
+    assert msg
+
     if pos:
         print("%s %r: *** %s" % (pos[0], pos[1], msg), file=sys.stderr)
     else:

--- a/pymake/pymake.py
+++ b/pymake/pymake.py
@@ -33,6 +33,7 @@ import pymake.pargs as pargs
 import pymake.submake as submake
 from pymake.debug import *
 from pymake.state import ParseState
+import pymake.constants as constants
 
 _debug = False
 
@@ -265,11 +266,10 @@ def _execute_statement_list(stmt_list, curr_rules, rulesdb, symtable):
 
     for tok in stmt_list:
         # sanity check; everything has to have a successful get_pos()
-        if _debug:
-            print("execute tok=",tok)
         _ = tok.get_pos()
 
         logger.debug("execute %r from %r", tok, tok.get_pos())
+#        logger.info("execute tok=%r from %r", tok, tok.get_pos())
 
         if isinstance(tok, Recipe):
             # We've found a recipe. Have we seen a rule yet?
@@ -516,6 +516,10 @@ def execute(makefile, args):
     symtable.add("MAKE", submake.create_helper())
     logger.debug("submake helper=%s", symtable.fetch("MAKE"))
 
+    # need this to exist so we don't modify the symbol table while iterating
+    # over the symbols dict (see symbol table get_exports())
+    symtable.add(constants.SHELLSTATUS, "")
+
     # "Contains the name of each makefile that is parsed by make, in the order
     # in which it was parsed. The name is appended just before make begins to
     # parse the makefile."
@@ -588,6 +592,8 @@ def execute(makefile, args):
     logger.info("Starting run of %s", makefile.get_pos()[0])
 
     for target in target_list:
+        exit_code = 0
+
         try:
             rule = rulesdb.get(target)
         except KeyError:

--- a/pymake/shell.py
+++ b/pymake/shell.py
@@ -170,8 +170,12 @@ def execute_tokens(token_list, symbol_table):
     if exe_result.errmsg:
         error_message(pos, exe_result.errmsg)
     else:
-        # otherwise report stderr
-        error_message(pos, exe_result.stderr)
+        # otherwise report stderr (if any)
+        if exe_result.stderr:
+            logger.error("command at %r failed with exit_code=%d", pos, exe_result.exit_code)
+            error_message(pos, exe_result.stderr)
+        else:
+            logger.error("command at %r failed with exit_code=%d (but stderr empty)", pos, exe_result.exit_code)
 
-    return ""
+    return exe_result.stdout
 

--- a/pymake/shell.py
+++ b/pymake/shell.py
@@ -151,8 +151,12 @@ def execute_tokens(token_list, symbol_table):
     # before exec'ing the shell cmd
     step2 = "".join(step1).strip()
 
+    symbol_table.ignore_recursion()
+
     # see comments in execute() about use_default_shell
     exe_result = execute(step2, symbol_table, use_default_shell=False)
+
+    symbol_table.allow_recursion()
 
     # GNU Make returns one whitespace separated string, no CR/LF
     # "all other newlines are replaced by spaces." gnu_make.pdf

--- a/pymake/symtablemk.py
+++ b/pymake/symtablemk.py
@@ -611,9 +611,8 @@ class SymbolTable(object):
 
     def get_exports(self):
         logger.debug("get_exports")
-        self.env_recursion += 1
+        assert self.env_recursion >= 0
         exports = { name:entry.eval(self) for name,entry in self.symbols.items() if entry.export }
-        self.env_recursion -= 1
         assert self.env_recursion >= 0
         return exports
 
@@ -640,4 +639,12 @@ class SymbolTable(object):
 
     def command_line_stop(self):
         self.command_line_flag = False
+
+    def ignore_recursion(self):
+        assert self.env_recursion >= 0
+        self.env_recursion += 1
+
+    def allow_recursion(self):
+        self.env_recursion -= 1
+        assert self.env_recursion >= 0
 

--- a/pymake/symtablemk.py
+++ b/pymake/symtablemk.py
@@ -101,7 +101,7 @@ class Entry:
         if isinstance(self._value, Symbol):
             logger.debug("recursive eval %r loop=%d name=%s at pos=%r", self, self.loop, self.name, self.get_pos())
             if self.loop > 0:
-                msg = "Recursive variable %r references itself (eventually)" % self.name
+                msg = "Recursive variable %r references itself (eventually)." % self.name
                 logger.debug("%s", msg)
                 if symbol_table.env_recursion > 0:
                     # if we're expanding a recursive variable for a shell

--- a/tests/env_recursion.mk
+++ b/tests/env_recursion.mk
@@ -1,0 +1,23 @@
+# Need a simple command that will give me the same response every time.
+# From the date man page:
+DATE:=date --date='TZ="America/Los_Angeles" 09:00 next Fri'
+
+# Example of loops in recursive variable references: ECHO requires value of NOW
+# but the $(shell) for NOW also requires ECHO.  The 'printenv' exit value is
+# non-zero when the var doesn't exist. But under GNU Make 'ECHO' env var does
+# exist so we see 'ok' in the output. The value of NOW in ECHO will be an empty
+# string.
+#
+NOW = $(shell $(DATE) ; printenv ECHO && echo ok)
+ECHO = $(shell echo NOW is __$(NOW)__)
+
+
+export NOW ECHO
+
+$(info NOW=$(NOW))
+$(info ECHO=$(ECHO))
+
+@:;@:
+	printenv ECHO
+	printenv NOW 
+

--- a/tests/test_env_recurse.py
+++ b/tests/test_env_recurse.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024 David Poole david.poole@ericsson.com
+
+# Test recursively expanded variables and their interaction with the shell
+
+import pytest
+
+import run
+import verify
+
+def test1():
+    makefile="""
+FOO=$(shell echo foo)
+export FOO
+
+all:
+	@printenv FOO
+"""
+    expect = (
+        "foo",
+    )
+
+    p = run.gnumake_string(makefile)
+    verify.compare_result_stdout(expect, p)
+
+    p = run.pymake_string(makefile)
+    verify.compare_result_stdout(expect, p)
+
+def test_not_exported():
+    makefile="""
+FOO=$(shell echo foo)
+
+all:
+	@printenv FOO
+"""
+    p = run.gnumake_should_fail(makefile)
+
+    p = run.pymake_should_fail(makefile)
+
+def test_export_loop():
+    makefile="""
+FOO=$(shell printenv BAR && echo BAR ok)
+BAR=$(shell printenv FOO && echo FOO ok)
+
+export FOO BAR
+
+all:
+	@printenv FOO
+	@printenv BAR
+"""
+    expect = (
+        "FOO ok BAR ok",
+        "BAR ok FOO ok"
+    )
+
+    p = run.gnumake_string(makefile)
+    verify.compare_result_stdout(expect, p)
+
+    p = run.pymake_string(makefile)
+    verify.compare_result_stdout(expect, p)
+
+def test_self_export():
+    # FOO must be in the environment but empty.
+    makefile="""
+FOO=$(shell printenv FOO && echo FOO ok)
+
+export FOO
+
+all:
+	@printenv FOO
+"""
+    expect = (
+        "FOO ok",
+    )
+
+    p = run.gnumake_string(makefile)
+    verify.compare_result_stdout(expect, p)
+
+    p = run.pymake_string(makefile)
+    verify.compare_result_stdout(expect, p)
+
+def test_unaccessed_self_reference():
+    # a definite self reference but FOO never accessed so who cares
+    makefile="""
+FOO=$(FOO)
+
+@:;@:
+"""
+    run.simple_test(makefile)
+
+def test_self_reference():
+    # a definite self reference
+    makefile="""
+FOO=$(FOO)
+$(info FOO=$(FOO))
+@:;@:
+"""
+
+    expect = "*** Recursive variable 'FOO' references itself (eventually)."
+
+    s = run.gnumake_should_fail(makefile)
+    assert expect in s, s
+
+    s = run.pymake_should_fail(makefile)
+    s_list = s.split("\n")
+    assert expect in s_list[-1]
+
+@pytest.mark.skip(reason="FIXME")
+def test_self_reference_rule():
+    makefile="""
+export FOO=$(FOO)
+
+all: ; @printenv FOO
+"""
+    p = run.gnumake_should_fail(makefile)
+
+    p = run.pymake_should_fail(makefile)
+

--- a/tests/test_env_recurse.py
+++ b/tests/test_env_recurse.py
@@ -37,6 +37,7 @@ all:
 
     p = run.pymake_should_fail(makefile)
 
+@pytest.mark.skip("TODO GNU Make 4.3 has different behaviors")
 def test_export_loop():
     makefile="""
 FOO=$(shell printenv BAR && echo BAR ok)
@@ -59,6 +60,7 @@ all:
     p = run.pymake_string(makefile)
     verify.compare_result_stdout(expect, p)
 
+@pytest.mark.skip("TODO GNU Make 4.3 has different behaviors")
 def test_self_export():
     # FOO must be in the environment but empty.
     makefile="""

--- a/tests/test_env_recurse.py
+++ b/tests/test_env_recurse.py
@@ -105,14 +105,18 @@ $(info FOO=$(FOO))
     s_list = s.split("\n")
     assert expect in s_list[-1]
 
-@pytest.mark.skip(reason="FIXME")
 def test_self_reference_rule():
     makefile="""
 export FOO=$(FOO)
 
 all: ; @printenv FOO
 """
-    p = run.gnumake_should_fail(makefile)
+    expect = "Recursive variable 'FOO' references itself (eventually)."
 
-    p = run.pymake_should_fail(makefile)
+    s = run.gnumake_should_fail(makefile)
+    assert expect in s, s
+
+    s = run.pymake_should_fail(makefile)
+    s_list = s.split("\n")
+    assert expect in s_list[-1]
 

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -112,6 +112,7 @@ infilename_list = (
     "multiline.mk",
     "ignoreandsilent.mk",
     "rule_without_target.mk",
+    "env_recursion.mk",
     
     "include.mk",
     # "automatic.mk",

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -112,7 +112,9 @@ infilename_list = (
     "multiline.mk",
     "ignoreandsilent.mk",
     "rule_without_target.mk",
-    "env_recursion.mk",
+
+    # FIXME fails with GNU Make 4.3
+#    "env_recursion.mk",
     
     "include.mk",
     # "automatic.mk",


### PR DESCRIPTION
Fix handling of recursive variables that are exported to the shell.  Some tests are disabled because GNU Make 4.3 has different behavior than GNU Make 4.4.1 which I used for dev.