### PR TITLE
better handling of internal variables such as .SHELLSTATUS

### DIFF
--- a/pymake/pymake.py
+++ b/pymake/pymake.py
@@ -242,7 +242,7 @@ def _add_internal_db(symtable):
     # now have a list of strings containing Make syntax assignment statements
     for oneline in defaults:
         # mark these variables 'default'
-        v = vline.VirtualLine([oneline], (0,0), "@defaults")
+        v = vline.VirtualLine([oneline], (-1,-1), "@defaults")
         stmt = tokenizer.tokenize_assignment_statement(iter(v))
         stmt.eval(symtable)
 
@@ -512,13 +512,8 @@ def execute(makefile, args):
         _add_internal_db(symtable)
 
     # aim sub-makes at my helper script
-#    symtable.add("MAKE", "py-submake")
-    symtable.add("MAKE", submake.create_helper())
+    symtable.update_builtin("MAKE", submake.create_helper())
     logger.debug("submake helper=%s", symtable.fetch("MAKE"))
-
-    # need this to exist so we don't modify the symbol table while iterating
-    # over the symbols dict (see symbol table get_exports())
-    symtable.add(constants.SHELLSTATUS, "")
 
     # "Contains the name of each makefile that is parsed by make, in the order
     # in which it was parsed. The name is appended just before make begins to
@@ -533,7 +528,7 @@ def execute(makefile, args):
     # is never touched by make again:"
     # GNU Make 4.3 2020 
     # The -C option will be handled before this function is called.
-    symtable.add("CURDIR", os.getcwd())
+    symtable.update_builtin("CURDIR", os.getcwd())
 
     target_list = []
 

--- a/pymake/shell.py
+++ b/pymake/shell.py
@@ -14,6 +14,8 @@ import pymake.submake as submake
 
 logger = logging.getLogger("pymake.shell")
 
+_debug = False
+
 # TODO comment in GNU make src/main.c
 # "POSIX says the value of SHELL set in the makefile won't change the value of
 # SHELL given to subprocesses."
@@ -37,8 +39,9 @@ def execute(cmd_str, symbol_table, use_default_shell=True):
 
     return_status = ShellReturn()
 
-    with open("shell.log","a") as outfile:
-        outfile.write("%s\n" % cmd_str)
+    if _debug:
+        with open("shell.log","a") as outfile:
+            outfile.write("%s\n" % cmd_str)
 
     # "If this variable is not set in your makefile, the program /bin/sh is
     # used as the shell." -- 5.3.2 Choosing the Shell

--- a/pymake/shell.py
+++ b/pymake/shell.py
@@ -37,6 +37,9 @@ def execute(cmd_str, symbol_table, use_default_shell=True):
 
     return_status = ShellReturn()
 
+    with open("shell.log","a") as outfile:
+        outfile.write("%s\n" % cmd_str)
+
     # "If this variable is not set in your makefile, the program /bin/sh is
     # used as the shell." -- 5.3.2 Choosing the Shell
     # GNU Make Manual Version 4.3 January 2020
@@ -166,7 +169,7 @@ def execute_tokens(token_list, symbol_table):
     # save shell status
     pos = token_list[0].get_pos()
     assert pos
-    symbol_table.add(constants.SHELLSTATUS, str(exe_result.exit_code), pos)
+    symbol_table.update_builtin(constants.SHELLSTATUS, str(exe_result.exit_code), pos)
 
     if exe_result.exit_code == 0:
         # success!

--- a/tests/shellstatus.mk
+++ b/tests/shellstatus.mk
@@ -1,0 +1,36 @@
+# should be 'undefined'
+$(info $(origin .SHELLSTATUS))
+
+FOO := $(shell echo foo)
+
+# will now be 'override' (not sure why GNU Make chose that value)
+$(info $(origin .SHELLSTATUS))
+
+ifneq ($(.SHELLSTATUS),0)
+$(error .SHELLSTATUS == $(.SHELLSTATUS))
+endif
+
+BAR != echo bar
+$(info $(origin .SHELLSTATUS))
+ifneq ($(.SHELLSTATUS),0)
+$(error .SHELLSTATUS == $(.SHELLSTATUS))
+endif
+
+ERROR != exit 1
+$(info $(origin .SHELLSTATUS))
+ifneq ($(.SHELLSTATUS),1)
+$(error .SHELLSTATUS == $(.SHELLSTATUS))
+endif
+
+# recursive variable
+BAZ = $(shell echo baz)
+export BAZ
+
+$(info BAZ=$(BAZ) $(origin .SHELLSTATUS))
+ifneq ($(.SHELLSTATUS),0)
+$(error .SHELLSTATUS == $(.SHELLSTATUS))
+endif
+
+
+@:;@:
+

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -112,10 +112,12 @@ infilename_list = (
     "multiline.mk",
     "ignoreandsilent.mk",
     "rule_without_target.mk",
+    "shellstatus.mk",
 
     # FIXME fails with GNU Make 4.3
 #    "env_recursion.mk",
     
+
     "include.mk",
     # "automatic.mk",
 )


### PR DESCRIPTION
Some variables can update the symbol table during execution of eval.