### PR TITLE
fix bug with multiple targets appending same recipe

### DIFF
--- a/pymake/rules.py
+++ b/pymake/rules.py
@@ -34,11 +34,12 @@ class Rule:
             assert '\t' not in target
             assert target
         assert all( (isinstance(s,str) for s in prereq_list) )
+        _ = recipe_list.makefile
 
         logger.debug("create rule target=%r at %r", target, pos)
         self.target = target
         self.prereq_list = list(prereq_list)
-        self.recipe_list = list(recipe_list)
+        self.recipe_list = recipe_list
         self.assignment_list = [assignment] if assignment else []
 
         _rule_sanity(pos, prereq_list, assignment)
@@ -88,6 +89,8 @@ class Rule:
 
 class RuleDB:
     def __init__(self):
+        # key: target (python string)
+        # value: instance of class Rule
         self.rules = {}
 
         # first rule added becomes the default
@@ -96,6 +99,8 @@ class RuleDB:
     def add(self, target, prereq_list, recipe_list, assignment, pos):
 
         # ha ha type checking
+        _ = recipe_list.makefile
+
         logger.debug("add rule target=%r at %r", target, pos)
 
         if not target:

--- a/pymake/symbol.py
+++ b/pymake/symbol.py
@@ -639,6 +639,9 @@ class RecipeList( Expression ) :
         super().__init__(recipe_list)
 
     def append(self, recipe):
+        # ha ha type checking
+        assert isinstance(recipe, Recipe), recipe
+
         self.token_list.append(recipe)
 
     def makefile(self):

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -8,7 +8,8 @@ import sys
 import re
 
 import pytest
-#import pymake
+
+import run
 
 # Find file relative to tests location
 test_dir = os.path.dirname(__file__)
@@ -134,10 +135,17 @@ def test_makefile(infilename):
             outfile.write(ground_truth)
     assert ground_truth == test_output
 
+@pytest.mark.skip(reason="run manually because slow")
+@pytest.mark.parametrize("infilename", infilename_list)
+def test_pymake_options(infilename):
+    # try some pymake args on the test makefiles
+    # (sanity test code paths)
+    filepath = os.path.join(example_dir, infilename)
+    s = run.run_pymake(filepath, extra_args=("--print-rule",))
+    s = run.run_pymake(filepath, extra_args=("-S",))
+    s = run.run_pymake(filepath, extra_args=("-n",))
+    s = run.run_pymake(filepath, extra_args=("--output", "/dev/null"))
 
-    # can I run pymake w/i pytest w/o spawning an additional python?
-#    print(os.getcwd())
-#    makefile = pymake.parse_makefile(infilename)
     
 def test_value():
     # TODO need some way of testing value() function w/o running afoul of my $(P) problem


### PR DESCRIPTION
Python references rose up to bite me. Each Rule has the same RecipeList instance but I was adding recipes to each RecipeList. So there were duplicate recipes for each rule.